### PR TITLE
Keep Azure operations on the selected target

### DIFF
--- a/automation-account/scripts/Invoke-RunbookValidation.ps1
+++ b/automation-account/scripts/Invoke-RunbookValidation.ps1
@@ -22,12 +22,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-$azAccount = az account show 2>$null | ConvertFrom-Json
-if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+Import-Module (Join-Path $PSScriptRoot '..\..\shared\scripts\Maester-SetupHelpers.psm1') -Force
+
+$azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
 if (-not $TenantId) { $TenantId = $azAccount.tenantId }
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 
 $apiVersion = '2023-11-01'

--- a/automation-account/scripts/Run-AzdPostProvision.ps1
+++ b/automation-account/scripts/Run-AzdPostProvision.ps1
@@ -222,7 +222,7 @@ $testParams['PassThru'] = $true
 
 $validationResult = & "$PSScriptRoot\Invoke-RunbookValidation.ps1" @testParams
 
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 $resourcesPath = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/resources?api-version=2021-04-01"
 $resourcesPayload = Invoke-RestMethod -Method GET -Uri "https://management.azure.com$resourcesPath" -Headers $armHeaders

--- a/automation-account/scripts/Run-AzdPreProvision.ps1
+++ b/automation-account/scripts/Run-AzdPreProvision.ps1
@@ -61,7 +61,7 @@ try {
     # List and delete all live jobSchedules via REST API
     # (az automation job-schedule CLI subcommand does not exist)
     $listUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$rgName/providers/Microsoft.Automation/automationAccounts/$aaName/jobSchedules?api-version=2023-11-01"
-    $listJson = az rest --method GET --uri $listUri -o json 2>$null
+    $listJson = az rest --method GET --uri $listUri --subscription $SubscriptionId -o json 2>$null
     if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($listJson)) {
       $liveSchedules = @(($listJson | ConvertFrom-Json).value)
       foreach ($js in $liveSchedules) {
@@ -69,7 +69,7 @@ try {
         if (-not [string]::IsNullOrWhiteSpace($jsId)) {
           Write-Host "  Deleting live jobSchedule '$jsId'..."
           $deleteUri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$rgName/providers/Microsoft.Automation/automationAccounts/$aaName/jobSchedules/${jsId}?api-version=2023-11-01"
-          az rest --method DELETE --uri $deleteUri 2>&1 | Out-Null
+          az rest --method DELETE --uri $deleteUri --subscription $SubscriptionId 2>&1 | Out-Null
         }
       }
     }

--- a/automation-account/scripts/Setup-PostDeploy.ps1
+++ b/automation-account/scripts/Setup-PostDeploy.ps1
@@ -59,12 +59,9 @@ if (-not $TenantId -and $env:AZURE_TENANT_ID) {
   $TenantId = $env:AZURE_TENANT_ID
 }
 
-if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-$azAccount = az account show 2>$null | ConvertFrom-Json
-if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+$azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
 if (-not $TenantId) { $TenantId = $azAccount.tenantId }
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 if (-not $EnvironmentName) {
   $EnvironmentName = if ($env:AZURE_ENV_NAME) { $env:AZURE_ENV_NAME } else { 'dev' }
@@ -162,10 +159,7 @@ $storageBlobDataReaderRoleId = "/subscriptions/$SubscriptionId/providers/Microso
 
 $signedInUser = $null
 try {
-  $signedInUserJson = az ad signed-in-user show --query "{id:id,userPrincipalName:userPrincipalName,displayName:displayName}" -o json 2>$null
-  if ($LASTEXITCODE -eq 0 -and $signedInUserJson) {
-    $signedInUser = $signedInUserJson | ConvertFrom-Json
-  }
+  $signedInUser = Invoke-GraphRestRequest -Method GET -Uri 'https://graph.microsoft.com/v1.0/me?$select=id,userPrincipalName,displayName' -TenantId $TenantId
 }
 catch {
   Write-Warning ("Could not resolve signed-in user from Azure CLI for Storage Blob Data Reader assignment. Error: {0}" -f $_.Exception.Message)

--- a/azure-devops/scripts/Setup-PostDeploy.ps1
+++ b/azure-devops/scripts/Setup-PostDeploy.ps1
@@ -645,7 +645,7 @@ if (-not $TenantId -and $currentContext -and $currentContext.Tenant) {
   $TenantId = $currentContext.Tenant.Id
 }
 
-$subscriptionName = az account show --query name -o tsv
+$subscriptionName = (Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId).name
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($subscriptionName)) {
   if ($currentContext -and $currentContext.Subscription) {
     $subscriptionName = $currentContext.Subscription.Name
@@ -928,10 +928,7 @@ $storageBlobDataReaderRoleId = "/subscriptions/$SubscriptionId/providers/Microso
 
 $signedInUser = $null
 try {
-  $signedInUserJson = az ad signed-in-user show --query "{id:id,userPrincipalName:userPrincipalName,displayName:displayName}" -o json 2>$null
-  if ($LASTEXITCODE -eq 0 -and $signedInUserJson) {
-    $signedInUser = $signedInUserJson | ConvertFrom-Json
-  }
+  $signedInUser = Invoke-GraphRestRequest -Method GET -Uri 'https://graph.microsoft.com/v1.0/me?$select=id,userPrincipalName,displayName' -TenantId $TenantId
 }
 catch {
   Write-Warning ("Could not resolve signed-in user from Azure CLI for Storage Blob Data Reader assignment. Error: {0}" -f $_.Exception.Message)

--- a/container-app-job/scripts/Build-MaesterImage.ps1
+++ b/container-app-job/scripts/Build-MaesterImage.ps1
@@ -72,7 +72,7 @@ $preferredJobName = "caj-maester-$($EnvironmentName.ToLower())"
 Write-Host "Updating Container App Job '$preferredJobName' to use image '$imageFqdn'..."
 
 $jobPath = "/subscriptions/$SubscriptionId/resourceGroups/$resolvedResourceGroupName/providers/Microsoft.App/jobs/${preferredJobName}?api-version=2024-03-01"
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 try {
   $jobPayload = Invoke-RestMethod -Method GET -Uri "https://management.azure.com$jobPath" -Headers $armHeaders

--- a/container-app-job/scripts/Invoke-JobValidation.ps1
+++ b/container-app-job/scripts/Invoke-JobValidation.ps1
@@ -20,12 +20,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-$azAccount = az account show 2>$null | ConvertFrom-Json
-if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+Import-Module (Join-Path $PSScriptRoot '..\..\shared\scripts\Maester-SetupHelpers.psm1') -Force
+
+$azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
 if (-not $TenantId) { $TenantId = $azAccount.tenantId }
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 
 $apiVersion = '2024-03-01'

--- a/container-app-job/scripts/Run-AzdPostProvision.ps1
+++ b/container-app-job/scripts/Run-AzdPostProvision.ps1
@@ -225,7 +225,7 @@ $testParams['PassThru'] = $true
 
 $validationResult = & "$PSScriptRoot\Invoke-JobValidation.ps1" @testParams
 
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 $resourcesPath = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/resources?api-version=2021-04-01"
 $resourcesPayload = Invoke-RestMethod -Method GET -Uri "https://management.azure.com$resourcesPath" -Headers $armHeaders

--- a/container-app-job/scripts/Setup-PostDeploy.ps1
+++ b/container-app-job/scripts/Setup-PostDeploy.ps1
@@ -59,12 +59,9 @@ if (-not $TenantId -and $env:AZURE_TENANT_ID) {
   $TenantId = $env:AZURE_TENANT_ID
 }
 
-if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-$azAccount = az account show 2>$null | ConvertFrom-Json
-if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+$azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
 if (-not $TenantId) { $TenantId = $azAccount.tenantId }
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 if (-not $EnvironmentName) {
   $EnvironmentName = if ($env:AZURE_ENV_NAME) { $env:AZURE_ENV_NAME } else { 'dev' }
@@ -162,10 +159,7 @@ $storageBlobDataReaderRoleId = "/subscriptions/$SubscriptionId/providers/Microso
 
 $signedInUser = $null
 try {
-  $signedInUserJson = az ad signed-in-user show --query "{id:id,userPrincipalName:userPrincipalName,displayName:displayName}" -o json 2>$null
-  if ($LASTEXITCODE -eq 0 -and $signedInUserJson) {
-    $signedInUser = $signedInUserJson | ConvertFrom-Json
-  }
+  $signedInUser = Invoke-GraphRestRequest -Method GET -Uri 'https://graph.microsoft.com/v1.0/me?$select=id,userPrincipalName,displayName' -TenantId $TenantId
 }
 catch {
   Write-Warning ("Could not resolve signed-in user from Azure CLI for Storage Blob Data Reader assignment. Error: {0}" -f $_.Exception.Message)

--- a/function-app/scripts/Invoke-FunctionValidation.ps1
+++ b/function-app/scripts/Invoke-FunctionValidation.ps1
@@ -20,12 +20,11 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-$azAccount = az account show 2>$null | ConvertFrom-Json
-if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+Import-Module (Join-Path $PSScriptRoot '..\..\shared\scripts\Maester-SetupHelpers.psm1') -Force
+
+$azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
 if (-not $TenantId) { $TenantId = $azAccount.tenantId }
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 
 # Discover function app if not specified
@@ -145,7 +144,7 @@ do {
       $storageName = $storage.name
 
       # List blobs in latest container to see if latest.html was recently updated
-      $plainToken = az account get-access-token --resource https://storage.azure.com/ --query accessToken -o tsv 2>$null
+      $plainToken = az account get-access-token --subscription $SubscriptionId --resource https://storage.azure.com/ --query accessToken -o tsv 2>$null
 
       $blobHeaders = @{
         'Authorization' = "Bearer $plainToken"

--- a/function-app/scripts/Run-AzdPostProvision.ps1
+++ b/function-app/scripts/Run-AzdPostProvision.ps1
@@ -263,7 +263,7 @@ else {
   }
 }
 
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 $resourcesPath = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/resources?api-version=2021-04-01"
 $resourcesPayload = Invoke-RestMethod -Method GET -Uri "https://management.azure.com$resourcesPath" -Headers $armHeaders

--- a/function-app/scripts/Setup-PostDeploy.ps1
+++ b/function-app/scripts/Setup-PostDeploy.ps1
@@ -63,12 +63,9 @@ if (-not $TenantId -and $env:AZURE_TENANT_ID) {
   $TenantId = $env:AZURE_TENANT_ID
 }
 
-if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-$azAccount = az account show 2>$null | ConvertFrom-Json
-if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+$azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
 if (-not $TenantId) { $TenantId = $azAccount.tenantId }
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $armHeaders = @{ Authorization = "Bearer $armToken" }
 if (-not $EnvironmentName) {
   $EnvironmentName = if ($env:AZURE_ENV_NAME) { $env:AZURE_ENV_NAME } else { 'dev' }
@@ -170,10 +167,7 @@ $storageBlobDataReaderRoleId = "/subscriptions/$SubscriptionId/providers/Microso
 
 $signedInUser = $null
 try {
-  $signedInUserJson = az ad signed-in-user show --query "{id:id,userPrincipalName:userPrincipalName,displayName:displayName}" -o json 2>$null
-  if ($LASTEXITCODE -eq 0 -and $signedInUserJson) {
-    $signedInUser = $signedInUserJson | ConvertFrom-Json
-  }
+  $signedInUser = Invoke-GraphRestRequest -Method GET -Uri 'https://graph.microsoft.com/v1.0/me?$select=id,userPrincipalName,displayName' -TenantId $TenantId
 }
 catch {
   Write-Warning ("Could not resolve signed-in user from Azure CLI for Storage Blob Data Reader assignment. Error: {0}" -f $_.Exception.Message)

--- a/shared/scripts/Get-ManagedIdentityPrincipal.ps1
+++ b/shared/scripts/Get-ManagedIdentityPrincipal.ps1
@@ -22,7 +22,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $resourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/$ProviderNamespace/$ResourceType/$ResourceName"
-$armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+$armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
 $payload = Invoke-RestMethod -Method GET -Uri "https://management.azure.com${resourceId}?api-version=$ApiVersion" -Headers @{ Authorization = "Bearer $armToken" }
 if (-not $payload) {
   throw "Failed to read resource '$resourceId'."

--- a/shared/scripts/Maester-Helpers.psm1
+++ b/shared/scripts/Maester-Helpers.psm1
@@ -155,7 +155,7 @@ function Remove-WebAppEasyAuthEntraApplications {
   param(
     [Parameter(Mandatory = $true)]
     [string]$ResourceGroupName,
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory = $true)]
     [string]$SubscriptionId,
     [Parameter(Mandatory = $false)]
     [string[]]$AdditionalApplicationObjectIds,
@@ -178,10 +178,7 @@ function Remove-WebAppEasyAuthEntraApplications {
     }
   }
 
-  $subscriptionArgs = @()
-  if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
-    $subscriptionArgs = @('--subscription', $SubscriptionId)
-  }
+  $subscriptionArgs = @('--subscription', $SubscriptionId)
 
   if (-not [string]::IsNullOrWhiteSpace($SubscriptionId)) {
     Write-Host "Discovering Web Apps in '$ResourceGroupName' for Easy Auth Entra app cleanup..."
@@ -226,7 +223,7 @@ function Remove-WebAppEasyAuthEntraApplications {
 
   $deletedAppObjectIds = New-Object System.Collections.Generic.HashSet[string]
   foreach ($appObjectId in $applicationObjectIds) {
-    $applicationRaw = & az rest --method get --url "https://graph.microsoft.com/v1.0/applications/${appObjectId}?`$select=id,appId,displayName"
+    $applicationRaw = & az rest --method get --url "https://graph.microsoft.com/v1.0/applications/${appObjectId}?`$select=id,appId,displayName" @subscriptionArgs
     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($applicationRaw)) {
       Write-Warning "Unable to query Entra application by objectId '$appObjectId'."
       continue
@@ -247,7 +244,7 @@ function Remove-WebAppEasyAuthEntraApplications {
     }
 
     Write-Host "Removing Easy Auth Entra application '$displayName' ($($application.appId))"
-    & az rest --method delete --url "https://graph.microsoft.com/v1.0/applications/$($application.id)" | Out-Null
+    & az rest --method delete --url "https://graph.microsoft.com/v1.0/applications/$($application.id)" @subscriptionArgs | Out-Null
     if ($LASTEXITCODE -ne 0) {
       Write-Warning "Failed to remove Entra application '$displayName' ($($application.id))."
       continue
@@ -257,14 +254,15 @@ function Remove-WebAppEasyAuthEntraApplications {
   }
 
   foreach ($clientId in $clientIds) {
-    $appByClientIdRaw = & az ad app show --id $clientId -o json 2>$null
+    $clientFilter = [System.Uri]::EscapeDataString("appId eq '$clientId'")
+    $appByClientIdRaw = & az rest --method get --url "https://graph.microsoft.com/v1.0/applications?`$filter=$clientFilter&`$select=id,appId,displayName" @subscriptionArgs 2>$null
     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($appByClientIdRaw)) {
       continue
     }
 
     try {
       $appByClientId = $appByClientIdRaw | ConvertFrom-Json
-      $apps = @($appByClientId)
+      $apps = @($appByClientId.value)
     }
     catch {
       Write-Warning "Failed to parse Entra application lookup for appId '$clientId'."
@@ -287,7 +285,7 @@ function Remove-WebAppEasyAuthEntraApplications {
       }
 
       Write-Host "Removing Easy Auth Entra application '$displayName' ($($app.appId))"
-      & az rest --method delete --url "https://graph.microsoft.com/v1.0/applications/$($app.id)" | Out-Null
+      & az rest --method delete --url "https://graph.microsoft.com/v1.0/applications/$($app.id)" @subscriptionArgs | Out-Null
       if ($LASTEXITCODE -ne 0) {
         Write-Warning "Failed to remove Entra application '$displayName' ($($app.id))."
         continue

--- a/shared/scripts/Maester-PreDownCleanup.psm1
+++ b/shared/scripts/Maester-PreDownCleanup.psm1
@@ -5,6 +5,19 @@ $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot 'Maester-Helpers.psm1') -Force
 
+function Resolve-TargetSubscriptionId {
+  param([Parameter(Mandatory = $false)][string]$SubscriptionId)
+
+  if ([string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    $SubscriptionId = $env:AZURE_SUBSCRIPTION_ID
+  }
+  if ([string]::IsNullOrWhiteSpace($SubscriptionId)) {
+    throw 'AZURE_SUBSCRIPTION_ID is required for cleanup.'
+  }
+
+  return $SubscriptionId
+}
+
 function Remove-ResourceGroupLocks {
   param(
     [Parameter(Mandatory = $true)]
@@ -20,7 +33,7 @@ function Remove-ResourceGroupLocks {
 
   Write-Host "Removing resource locks in '$ResourceGroupName' (if any)..."
   $locksUrl = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Authorization/locks?api-version=2016-09-01"
-  $armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv 2>$null
+  $armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv 2>$null
   $locksPayload = $null
   try {
     $locksPayload = Invoke-RestMethod -Method GET -Uri $locksUrl -Headers @{ Authorization = "Bearer $armToken" }
@@ -54,6 +67,9 @@ function Remove-ResourceGroupLocks {
 function Remove-TrackedDirectoryRoleAssignments {
   param(
     [Parameter(Mandatory = $false)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $false)]
     [AllowEmptyCollection()]
     [string[]]$AssignmentIds = @()
   )
@@ -62,8 +78,9 @@ function Remove-TrackedDirectoryRoleAssignments {
     return
   }
 
+  $SubscriptionId = Resolve-TargetSubscriptionId -SubscriptionId $SubscriptionId
   Write-Host 'Removing Teams Reader Entra role assignments created by this environment...'
-  $graphToken = az account get-access-token --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
+  $graphToken = az account get-access-token --subscription $SubscriptionId --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
   $graphHeaders = @{ Authorization = "Bearer $graphToken" }
   foreach ($assignmentId in @($AssignmentIds)) {
     if ([string]::IsNullOrWhiteSpace($assignmentId)) {
@@ -82,6 +99,9 @@ function Remove-TrackedDirectoryRoleAssignments {
 function Remove-TrackedAzureRoleAssignments {
   param(
     [Parameter(Mandatory = $false)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $false)]
     [AllowEmptyCollection()]
     [string[]]$RoleAssignmentIds = @()
   )
@@ -90,13 +110,14 @@ function Remove-TrackedAzureRoleAssignments {
     return
   }
 
+  $SubscriptionId = Resolve-TargetSubscriptionId -SubscriptionId $SubscriptionId
   Write-Host 'Removing Azure RBAC role assignments created by this environment...'
   foreach ($roleAssignmentId in @($RoleAssignmentIds)) {
     if ([string]::IsNullOrWhiteSpace($roleAssignmentId)) {
       continue
     }
 
-    & az role assignment delete --ids $roleAssignmentId | Out-Null
+    & az role assignment delete --ids $roleAssignmentId --subscription $SubscriptionId | Out-Null
     if ($LASTEXITCODE -ne 0) {
       Write-Warning "Failed to remove Azure RBAC role assignment id '$roleAssignmentId'."
     }
@@ -105,6 +126,9 @@ function Remove-TrackedAzureRoleAssignments {
 
 function Remove-TrackedExchangeAppRoleAssignments {
   param(
+    [Parameter(Mandatory = $false)]
+    [string]$SubscriptionId,
+
     [Parameter(Mandatory = $false)]
     [string]$PrincipalObjectId,
 
@@ -117,8 +141,9 @@ function Remove-TrackedExchangeAppRoleAssignments {
     return
   }
 
+  $SubscriptionId = Resolve-TargetSubscriptionId -SubscriptionId $SubscriptionId
   Write-Host 'Removing Exchange appRoleAssignments created by this environment...'
-  $graphToken = az account get-access-token --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
+  $graphToken = az account get-access-token --subscription $SubscriptionId --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
   $graphHeaders = @{ Authorization = "Bearer $graphToken" }
   foreach ($assignmentId in @($AssignmentIds)) {
     if ([string]::IsNullOrWhiteSpace($assignmentId)) {
@@ -137,6 +162,9 @@ function Remove-TrackedExchangeAppRoleAssignments {
 function Remove-ExchangeRbacAssignments {
   param(
     [Parameter(Mandatory = $false)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $false)]
     [string]$RoleAssigneeDisplayName
   )
 
@@ -144,6 +172,7 @@ function Remove-ExchangeRbacAssignments {
     return
   }
 
+  $SubscriptionId = Resolve-TargetSubscriptionId -SubscriptionId $SubscriptionId
   Write-Host "Attempting Exchange RBAC cleanup for '$RoleAssigneeDisplayName' (best-effort)..."
   try {
     if (-not (Test-ModuleAvailable -ModuleName 'ExchangeOnlineManagement')) {
@@ -154,10 +183,10 @@ function Remove-ExchangeRbacAssignments {
     $exoToken = $null
     $exoOrganization = $null
     try {
-      $exoToken = (az account get-access-token --resource https://outlook.office365.com --query accessToken -o tsv 2>$null)
+      $exoToken = (az account get-access-token --subscription $SubscriptionId --resource https://outlook.office365.com --query accessToken -o tsv 2>$null)
       if ($exoToken) {
         try {
-          $graphToken = az account get-access-token --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
+          $graphToken = az account get-access-token --subscription $SubscriptionId --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
           $orgData = Invoke-RestMethod -Method GET -Uri 'https://graph.microsoft.com/v1.0/organization?$select=verifiedDomains' -Headers @{ Authorization = "Bearer $graphToken" }
           if ($orgData.value -and $orgData.value.Count -gt 0) {
             $initialDomain = @($orgData.value[0].verifiedDomains | Where-Object { $_.isInitial -eq $true }) | Select-Object -First 1
@@ -231,10 +260,10 @@ function Invoke-MaesterStandardPreDownCleanup {
   $exoAppRoleAssignmentIds = @(ConvertFrom-JsonArrayOrEmpty -Json (Get-AzdEnvironmentValue -Values $envValues -Name 'EXO_APPROLE_ASSIGNMENT_IDS'))
   $exoServicePrincipalDisplayName = Get-AzdEnvironmentValue -Values $envValues -Name 'EXO_SERVICE_PRINCIPAL_DISPLAY_NAME'
 
-  Remove-TrackedDirectoryRoleAssignments -AssignmentIds $teamsRoleAssignmentIds
-  Remove-TrackedAzureRoleAssignments -RoleAssignmentIds $azureRoleAssignmentIds
-  Remove-TrackedExchangeAppRoleAssignments -PrincipalObjectId $miPrincipalId -AssignmentIds $exoAppRoleAssignmentIds
-  Remove-ExchangeRbacAssignments -RoleAssigneeDisplayName $exoServicePrincipalDisplayName
+  Remove-TrackedDirectoryRoleAssignments -SubscriptionId $subscriptionId -AssignmentIds $teamsRoleAssignmentIds
+  Remove-TrackedAzureRoleAssignments -SubscriptionId $subscriptionId -RoleAssignmentIds $azureRoleAssignmentIds
+  Remove-TrackedExchangeAppRoleAssignments -SubscriptionId $subscriptionId -PrincipalObjectId $miPrincipalId -AssignmentIds $exoAppRoleAssignmentIds
+  Remove-ExchangeRbacAssignments -SubscriptionId $subscriptionId -RoleAssigneeDisplayName $exoServicePrincipalDisplayName
 
   if (-not [string]::IsNullOrWhiteSpace($resourceGroupName)) {
     Remove-WebAppEasyAuthEntraApplications `
@@ -250,6 +279,9 @@ function Invoke-MaesterStandardPreDownCleanup {
 function Invoke-AdoRest {
   param(
     [Parameter(Mandatory = $true)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $true)]
     [ValidateSet('GET', 'POST', 'PUT', 'PATCH', 'DELETE')]
     [string]$Method,
 
@@ -263,7 +295,7 @@ function Invoke-AdoRest {
     [switch]$AllowNotFound
   )
 
-  $adoToken = az account get-access-token --resource '499b84ac-1321-427f-aa17-267ca6975798' --query accessToken -o tsv 2>$null
+  $adoToken = az account get-access-token --subscription $SubscriptionId --resource '499b84ac-1321-427f-aa17-267ca6975798' --query accessToken -o tsv 2>$null
   $adoHeaders = @{ Authorization = "Bearer $adoToken" }
 
   $invokeParams = @{
@@ -310,6 +342,9 @@ function Invoke-AdoRest {
 function Remove-AdoServiceConnectionById {
   param(
     [Parameter(Mandatory = $true)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $true)]
     [string]$Organization,
 
     [Parameter(Mandatory = $true)]
@@ -330,11 +365,11 @@ function Remove-AdoServiceConnectionById {
 
   foreach ($deleteUri in @($deleteUris | Select-Object -Unique)) {
     try {
-      Invoke-AdoRest -Method DELETE -Uri $deleteUri -AllowNotFound | Out-Null
+      Invoke-AdoRest -SubscriptionId $SubscriptionId -Method DELETE -Uri $deleteUri -AllowNotFound | Out-Null
       $verificationUri = "https://dev.azure.com/$Organization/$ProjectEncoded/_apis/serviceendpoint/endpoints/$($ServiceConnectionId)?api-version=7.1-preview.4"
       $maxVerifyAttempts = 6
       for ($attempt = 1; $attempt -le $maxVerifyAttempts; $attempt++) {
-        $verification = Invoke-AdoRest -Method GET -Uri $verificationUri -AllowNotFound
+        $verification = Invoke-AdoRest -SubscriptionId $SubscriptionId -Method GET -Uri $verificationUri -AllowNotFound
         if ($null -eq $verification) {
           return $true
         }
@@ -355,6 +390,9 @@ function Remove-AdoServiceConnectionById {
 function Remove-TrackedBaseRoleAssignments {
   param(
     [Parameter(Mandatory = $false)]
+    [string]$SubscriptionId,
+
+    [Parameter(Mandatory = $false)]
     [AllowEmptyCollection()]
     [string[]]$RoleAssignmentIds = @()
   )
@@ -363,13 +401,14 @@ function Remove-TrackedBaseRoleAssignments {
     return
   }
 
+  $SubscriptionId = Resolve-TargetSubscriptionId -SubscriptionId $SubscriptionId
   Write-Host 'Removing base Azure role assignments created for Azure DevOps workload identity...'
   foreach ($roleAssignmentId in @($RoleAssignmentIds)) {
     if ([string]::IsNullOrWhiteSpace($roleAssignmentId)) {
       continue
     }
 
-    & az role assignment delete --ids $roleAssignmentId | Out-Null
+    & az role assignment delete --ids $roleAssignmentId --subscription $SubscriptionId | Out-Null
     if ($LASTEXITCODE -ne 0) {
       Write-Warning "Failed to remove base role assignment id '$roleAssignmentId'."
     }
@@ -417,7 +456,7 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
     try {
       $exchangeManageAsAppRoleId = 'dc50a0fb-09a3-484d-be87-e023b12c6440'
       $appAssignmentsUrl = "https://graph.microsoft.com/v1.0/servicePrincipals/$workloadServicePrincipalObjectId/appRoleAssignments?`$select=id,appRoleId"
-      $graphToken = az account get-access-token --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
+      $graphToken = az account get-access-token --subscription $subscriptionId --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
       $appAssignmentsPayload = Invoke-RestMethod -Method GET -Uri $appAssignmentsUrl -Headers @{ Authorization = "Bearer $graphToken" }
       $resolvedAssignmentIds = @($appAssignmentsPayload.value | Where-Object { $_.appRoleId -eq $exchangeManageAsAppRoleId } | ForEach-Object { $_.id } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
       if ($resolvedAssignmentIds.Count -gt 0) {
@@ -431,19 +470,18 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
   }
 
   if (-not [string]::IsNullOrWhiteSpace($subscriptionId)) {
-    az account set --subscription $subscriptionId 2>$null | Out-Null
-    $azAccount = az account show 2>$null | ConvertFrom-Json
-    if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
+    & az account get-access-token --subscription $subscriptionId --resource https://management.azure.com/ --output none 2>$null
+    if ($LASTEXITCODE -ne 0) { throw "Subscription '$subscriptionId' is not available in the current Azure CLI login." }
   }
 
   if (-not [string]::IsNullOrWhiteSpace($resourceGroupName) -and -not [string]::IsNullOrWhiteSpace($subscriptionId)) {
     Remove-ResourceGroupLocks -SubscriptionId $subscriptionId -ResourceGroupName $resourceGroupName
   }
 
-  Remove-TrackedDirectoryRoleAssignments -AssignmentIds $teamsRoleAssignmentIds
-  Remove-TrackedAzureRoleAssignments -RoleAssignmentIds $azureRoleAssignmentIds
-  Remove-TrackedBaseRoleAssignments -RoleAssignmentIds $baseRoleAssignmentIds
-  Remove-TrackedExchangeAppRoleAssignments -PrincipalObjectId $workloadServicePrincipalObjectId -AssignmentIds $exoAppRoleAssignmentIds
+  Remove-TrackedDirectoryRoleAssignments -SubscriptionId $subscriptionId -AssignmentIds $teamsRoleAssignmentIds
+  Remove-TrackedAzureRoleAssignments -SubscriptionId $subscriptionId -RoleAssignmentIds $azureRoleAssignmentIds
+  Remove-TrackedBaseRoleAssignments -SubscriptionId $subscriptionId -RoleAssignmentIds $baseRoleAssignmentIds
+  Remove-TrackedExchangeAppRoleAssignments -SubscriptionId $subscriptionId -PrincipalObjectId $workloadServicePrincipalObjectId -AssignmentIds $exoAppRoleAssignmentIds
 
   $exchangeIdentityCandidates = @(
     @(
@@ -455,7 +493,7 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
   )
 
   foreach ($identity in $exchangeIdentityCandidates) {
-    Remove-ExchangeRbacAssignments -RoleAssigneeDisplayName $identity
+    Remove-ExchangeRbacAssignments -SubscriptionId $subscriptionId -RoleAssigneeDisplayName $identity
   }
 
   $adoProjectEncoded = $null
@@ -468,7 +506,7 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
       $adoProjectEncoded = [System.Uri]::EscapeDataString($adoProject)
 
       try {
-        $projectResponse = Invoke-AdoRest -Method GET -Uri "https://dev.azure.com/$adoOrganization/_apis/projects/$($adoProjectEncoded)?api-version=7.1-preview.4"
+        $projectResponse = Invoke-AdoRest -SubscriptionId $subscriptionId -Method GET -Uri "https://dev.azure.com/$adoOrganization/_apis/projects/$($adoProjectEncoded)?api-version=7.1-preview.4"
         if ($projectResponse -and $projectResponse.id) {
           $adoProjectId = [string]$projectResponse.id
         }
@@ -479,15 +517,15 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
 
       if (-not [string]::IsNullOrWhiteSpace($adoPipelineId)) {
         Write-Host "Removing Azure DevOps pipeline '$adoPipelineName' ($adoPipelineId)..."
-        Invoke-AdoRest -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/build/definitions/$($adoPipelineId)?api-version=7.1" | Out-Null
+        Invoke-AdoRest -SubscriptionId $subscriptionId -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/build/definitions/$($adoPipelineId)?api-version=7.1" | Out-Null
       }
       elseif (-not [string]::IsNullOrWhiteSpace($adoPipelineName)) {
         try {
-          $pipelines = Invoke-AdoRest -Method GET -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/pipelines?api-version=7.1-preview.1"
+          $pipelines = Invoke-AdoRest -SubscriptionId $subscriptionId -Method GET -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/pipelines?api-version=7.1-preview.1"
           $pipeline = @($pipelines.value | Where-Object { $_.name -eq $adoPipelineName } | Select-Object -First 1)
           if ($pipeline.Count -gt 0 -and $pipeline[0].id) {
             Write-Host "Removing Azure DevOps pipeline '$adoPipelineName' ($($pipeline[0].id))..."
-            Invoke-AdoRest -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/build/definitions/$($pipeline[0].id)?api-version=7.1" | Out-Null
+            Invoke-AdoRest -SubscriptionId $subscriptionId -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/build/definitions/$($pipeline[0].id)?api-version=7.1" | Out-Null
           }
         }
         catch {
@@ -496,7 +534,7 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
 
       if (-not [string]::IsNullOrWhiteSpace($adoServiceConnectionId)) {
         Write-Host "Removing Azure DevOps service connection '$adoServiceConnectionName' ($adoServiceConnectionId)..."
-        $removed = Remove-AdoServiceConnectionById -Organization $adoOrganization -ProjectEncoded $adoProjectEncoded -ServiceConnectionId $adoServiceConnectionId -ProjectId $adoProjectId
+        $removed = Remove-AdoServiceConnectionById -SubscriptionId $subscriptionId -Organization $adoOrganization -ProjectEncoded $adoProjectEncoded -ServiceConnectionId $adoServiceConnectionId -ProjectId $adoProjectId
         if (-not $removed) {
           Write-Warning "Failed to remove Azure DevOps service connection id '$adoServiceConnectionId'."
           $retryAdoServiceConnectionId = $adoServiceConnectionId
@@ -506,11 +544,11 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
       elseif (-not [string]::IsNullOrWhiteSpace($adoServiceConnectionName)) {
         try {
           $encodedEndpointName = [System.Uri]::EscapeDataString($adoServiceConnectionName)
-          $serviceConnections = Invoke-AdoRest -Method GET -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/serviceendpoint/endpoints?endpointNames=$encodedEndpointName&includeFailed=true&api-version=7.1-preview.4"
+          $serviceConnections = Invoke-AdoRest -SubscriptionId $subscriptionId -Method GET -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/serviceendpoint/endpoints?endpointNames=$encodedEndpointName&includeFailed=true&api-version=7.1-preview.4"
           $serviceConnection = @($serviceConnections.value | Where-Object { $_.name -eq $adoServiceConnectionName } | Select-Object -First 1)
           if ($serviceConnection.Count -gt 0 -and $serviceConnection[0].id) {
             Write-Host "Removing Azure DevOps service connection '$adoServiceConnectionName' ($($serviceConnection[0].id))..."
-            $removed = Remove-AdoServiceConnectionById -Organization $adoOrganization -ProjectEncoded $adoProjectEncoded -ServiceConnectionId ([string]$serviceConnection[0].id) -ProjectId $adoProjectId
+            $removed = Remove-AdoServiceConnectionById -SubscriptionId $subscriptionId -Organization $adoOrganization -ProjectEncoded $adoProjectEncoded -ServiceConnectionId ([string]$serviceConnection[0].id) -ProjectId $adoProjectId
             if (-not $removed) {
               Write-Warning "Failed to remove Azure DevOps service connection '$adoServiceConnectionName' ($($serviceConnection[0].id))."
               $retryAdoServiceConnectionId = [string]$serviceConnection[0].id
@@ -524,15 +562,15 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
 
       if (-not [string]::IsNullOrWhiteSpace($adoRepositoryId)) {
         Write-Host "Removing Azure DevOps repository '$adoRepositoryName' ($adoRepositoryId)..."
-        Invoke-AdoRest -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/git/repositories/$($adoRepositoryId)?api-version=7.1-preview.1" | Out-Null
+        Invoke-AdoRest -SubscriptionId $subscriptionId -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/git/repositories/$($adoRepositoryId)?api-version=7.1-preview.1" | Out-Null
       }
       elseif (-not [string]::IsNullOrWhiteSpace($adoRepositoryName)) {
         try {
-          $repos = Invoke-AdoRest -Method GET -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/git/repositories?api-version=7.1-preview.1"
+          $repos = Invoke-AdoRest -SubscriptionId $subscriptionId -Method GET -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/git/repositories?api-version=7.1-preview.1"
           $repo = @($repos.value | Where-Object { $_.name -eq $adoRepositoryName } | Select-Object -First 1)
           if ($repo.Count -gt 0 -and $repo[0].id) {
             Write-Host "Removing Azure DevOps repository '$adoRepositoryName' ($($repo[0].id))..."
-            Invoke-AdoRest -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/git/repositories/$($repo[0].id)?api-version=7.1-preview.1" | Out-Null
+            Invoke-AdoRest -SubscriptionId $subscriptionId -Method DELETE -Uri "https://dev.azure.com/$adoOrganization/$adoProjectEncoded/_apis/git/repositories/$($repo[0].id)?api-version=7.1-preview.1" | Out-Null
           }
         }
         catch {
@@ -547,7 +585,7 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
   if (-not [string]::IsNullOrWhiteSpace($workloadAppObjectId)) {
     Write-Host "Removing workload identity Entra application object '$workloadAppObjectId'..."
     try {
-      $graphToken = az account get-access-token --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
+      $graphToken = az account get-access-token --subscription $subscriptionId --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
       Invoke-RestMethod -Method DELETE -Uri "https://graph.microsoft.com/v1.0/applications/$workloadAppObjectId" -Headers @{ Authorization = "Bearer $graphToken" } | Out-Null
     }
     catch {
@@ -556,8 +594,15 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
   }
   elseif (-not [string]::IsNullOrWhiteSpace($workloadAppId)) {
     Write-Host "Removing workload identity Entra application appId '$workloadAppId'..."
-    & az ad app delete --id $workloadAppId | Out-Null
-    if ($LASTEXITCODE -ne 0) {
+    try {
+      $graphToken = az account get-access-token --subscription $subscriptionId --resource https://graph.microsoft.com/ --query accessToken -o tsv 2>$null
+      $filter = [System.Uri]::EscapeDataString("appId eq '$workloadAppId'")
+      $application = (Invoke-RestMethod -Method GET -Uri "https://graph.microsoft.com/v1.0/applications?`$filter=$filter&`$select=id" -Headers @{ Authorization = "Bearer $graphToken" }).value | Select-Object -First 1
+      if ($application.id) {
+        Invoke-RestMethod -Method DELETE -Uri "https://graph.microsoft.com/v1.0/applications/$($application.id)" -Headers @{ Authorization = "Bearer $graphToken" } | Out-Null
+      }
+    }
+    catch {
       Write-Warning "Failed to remove Entra application appId '$workloadAppId'."
     }
   }
@@ -567,7 +612,7 @@ function Invoke-MaesterAzureDevOpsPreDownCleanup {
       -not [string]::IsNullOrWhiteSpace($adoProjectEncoded)) {
     Write-Host "Retrying Azure DevOps service connection '$retryAdoServiceConnectionName' ($retryAdoServiceConnectionId) after workload identity cleanup..."
     Start-Sleep -Seconds 10
-    $removed = Remove-AdoServiceConnectionById -Organization $adoOrganization -ProjectEncoded $adoProjectEncoded -ServiceConnectionId $retryAdoServiceConnectionId -ProjectId $adoProjectId
+    $removed = Remove-AdoServiceConnectionById -SubscriptionId $subscriptionId -Organization $adoOrganization -ProjectEncoded $adoProjectEncoded -ServiceConnectionId $retryAdoServiceConnectionId -ProjectId $adoProjectId
     if (-not $removed) {
       Write-Warning "Retry failed for Azure DevOps service connection '$retryAdoServiceConnectionName' ($retryAdoServiceConnectionId)."
     }

--- a/shared/scripts/Maester-PreProvision.psm1
+++ b/shared/scripts/Maester-PreProvision.psm1
@@ -74,10 +74,7 @@ function Invoke-MaesterPreProvision {
     }
   }
 
-  if ($SubscriptionId) { az account set --subscription $SubscriptionId 2>$null | Out-Null }
-  $azAccount = az account show 2>$null | ConvertFrom-Json
-  if (-not $azAccount) { throw 'Not authenticated. Run: azd auth login' }
-  if (-not $SubscriptionId) { $SubscriptionId = $azAccount.id }
+  $azAccount = Get-AzCliSubscriptionContext -SubscriptionId $SubscriptionId -TenantId $TenantId
   if (-not $TenantId) { $TenantId = $azAccount.tenantId }
 
   if ([string]::IsNullOrWhiteSpace($TenantId)) {

--- a/shared/scripts/Maester-PreUp.psm1
+++ b/shared/scripts/Maester-PreUp.psm1
@@ -35,10 +35,7 @@ function Invoke-MaesterPreUp {
 
   $subscriptionId = Get-ValueFromEnvironmentOrAzd -Name 'AZURE_SUBSCRIPTION_ID' -AzdValues $envValues
   if ([string]::IsNullOrWhiteSpace($subscriptionId)) {
-    $subscriptionId = (& az account show --query id -o tsv 2>$null)
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($subscriptionId)) {
-      throw "AZURE_SUBSCRIPTION_ID is required to resolve resource group '$resourceGroupName'."
-    }
+    throw "AZURE_SUBSCRIPTION_ID is required to resolve resource group '$resourceGroupName'."
   }
 
   $exists = (& az group exists --name $resourceGroupName --subscription $subscriptionId -o tsv 2>$null)

--- a/shared/scripts/Maester-SetupHelpers.psm1
+++ b/shared/scripts/Maester-SetupHelpers.psm1
@@ -142,6 +142,33 @@ function Set-AzdEnvJsonArray {
 
 # ── Authentication helpers ────────────────────────────────────────────────────
 
+function Get-AzCliSubscriptionContext {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SubscriptionId,
+    [Parameter(Mandatory = $false)]
+    [string]$TenantId
+  )
+
+  $accountsJson = (& az account list -o json 2>$null)
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($accountsJson)) {
+    throw 'Not authenticated. Run: azd auth login'
+  }
+
+  $account = @($accountsJson | ConvertFrom-Json) |
+    Where-Object { $_.id -ieq $SubscriptionId } |
+    Select-Object -First 1
+  if (-not $account) {
+    throw "Subscription '$SubscriptionId' is not available in the current Azure CLI login."
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($TenantId) -and $account.tenantId -ine $TenantId) {
+    throw "Subscription '$SubscriptionId' belongs to tenant '$($account.tenantId)', not selected tenant '$TenantId'."
+  }
+
+  return $account
+}
+
 function Get-AzCliAccessToken {
   param(
     [Parameter(Mandatory = $true)]
@@ -187,7 +214,7 @@ function Get-GraphAccessToken {
   }
 
   if ($AllowInteractiveLogin) {
-    Confirm-AzureLogin
+    Confirm-AzureLogin -TenantId $TenantId
     $token = Get-AzCliAccessToken -Resource 'https://graph.microsoft.com' -TenantId $TenantId
     if ($token) {
       return $token
@@ -333,8 +360,14 @@ function Connect-ExchangeOnlineSilent {
 }
 
 function Confirm-AzureLogin {
+  param([Parameter(Mandatory = $false)][string]$TenantId)
+
   try {
-    $null = az account show --output none 2>$null
+    $tokenArgs = @('account', 'get-access-token', '--resource', 'https://graph.microsoft.com', '--output', 'none')
+    if (-not [string]::IsNullOrWhiteSpace($TenantId)) {
+      $tokenArgs += @('--tenant', $TenantId)
+    }
+    $null = & az @tokenArgs 2>$null
     if ($LASTEXITCODE -eq 0) {
       return
     }
@@ -343,7 +376,11 @@ function Confirm-AzureLogin {
   }
 
   Write-Host 'No active Azure CLI login detected. Opening Azure login...'
-  & az login | Out-Null
+  $loginArgs = @('login')
+  if (-not [string]::IsNullOrWhiteSpace($TenantId)) {
+    $loginArgs += @('--tenant', $TenantId)
+  }
+  & az @loginArgs | Out-Null
   if ($LASTEXITCODE -ne 0) {
     throw 'Azure login failed.'
   }
@@ -550,7 +587,7 @@ function Test-AzureReaderRoleAssignment {
     "/subscriptions/$SubscriptionId/providers/Microsoft.Authorization/roleDefinitions/$readerRoleGuid"
   }
 
-  $armToken = az account get-access-token --resource https://management.azure.com/ --query accessToken -o tsv
+  $armToken = az account get-access-token --subscription $SubscriptionId --resource https://management.azure.com/ --query accessToken -o tsv
   $armHeaders = @{ Authorization = "Bearer $armToken" }
 
   # Pre-check: look for an existing Reader assignment for this principal at this scope

--- a/shared/scripts/Maester-UpWizard.psm1
+++ b/shared/scripts/Maester-UpWizard.psm1
@@ -485,7 +485,7 @@ function Invoke-MaesterUpWizard {
         $existingRepoFound = $false
         try {
           $projectEncoded = [System.Uri]::EscapeDataString($project)
-          $adoToken = az account get-access-token --resource '499b84ac-1321-427f-aa17-267ca6975798' --query accessToken -o tsv 2>$null
+          $adoToken = az account get-access-token --subscription $SubscriptionId --resource '499b84ac-1321-427f-aa17-267ca6975798' --query accessToken -o tsv 2>$null
           $reposPayload = Invoke-RestMethod -Method GET -Uri "https://dev.azure.com/$organization/$projectEncoded/_apis/git/repositories?api-version=7.1-preview.1" -Headers @{ Authorization = "Bearer $adoToken" }
           if ($reposPayload) {
             $existingRepoFound = @($reposPayload.value | Where-Object { $_.name -ieq $repositoryName }).Count -gt 0

--- a/tests/TargetContext.Tests.ps1
+++ b/tests/TargetContext.Tests.ps1
@@ -1,0 +1,54 @@
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$scriptFiles = Get-ChildItem -LiteralPath $repoRoot -Recurse -File -Include *.ps1, *.psm1 |
+  Where-Object { $_.FullName -notmatch '[\\/](?:\.git|tests)[\\/]' }
+
+Import-Module (Join-Path $repoRoot 'shared\scripts\Maester-SetupHelpers.psm1') -Force
+
+Describe 'Azure CLI target context' {
+  It 'does not mutate the global default subscription' {
+    $matches = $scriptFiles | Select-String -Pattern '\baz account set\b'
+    $matches | Should -BeNullOrEmpty
+  }
+
+  It 'targets every access token request explicitly' {
+    $matches = $scriptFiles | Select-String -Pattern '\baz account get-access-token\b'
+    foreach ($match in $matches) {
+      $match.Line | Should -Match '--(?:subscription|tenant)\b'
+    }
+  }
+
+  It 'targets every Azure CLI REST request explicitly' {
+    $matches = $scriptFiles | Select-String -Pattern '\baz rest\b'
+    foreach ($match in $matches) {
+      $match.Line | Should -Match '(?:--subscription\b|@subscriptionArgs\b)'
+    }
+  }
+}
+
+Describe 'Selected subscription validation' {
+  InModuleScope Maester-SetupHelpers {
+    BeforeEach {
+      Mock az {
+        $global:LASTEXITCODE = 0
+        '[{"id":"11111111-1111-1111-1111-111111111111","tenantId":"22222222-2222-2222-2222-222222222222"}]'
+      }
+    }
+
+    It 'returns the requested subscription without changing the default' {
+      $account = Get-AzCliSubscriptionContext `
+        -SubscriptionId '11111111-1111-1111-1111-111111111111' `
+        -TenantId '22222222-2222-2222-2222-222222222222'
+
+      $account.id | Should -Be '11111111-1111-1111-1111-111111111111'
+      Should -Invoke az -Times 1 -Exactly
+    }
+
+    It 'rejects a subscription from a different tenant' {
+      {
+        Get-AzCliSubscriptionContext `
+          -SubscriptionId '11111111-1111-1111-1111-111111111111' `
+          -TenantId '33333333-3333-3333-3333-333333333333'
+      } | Should -Throw '*belongs to tenant*'
+    }
+  }
+}


### PR DESCRIPTION
## Summary`n- remove global Azure CLI subscription mutation from every deployment variant`n- validate the selected subscription and tenant without changing CLI defaults`n- target every Azure CLI token and REST request explicitly`n- use explicit-tenant Microsoft Graph `/me` lookups instead of inherited `az ad` context`n- add repository-wide Pester regression coverage for the target-context contract`n`n## Local validation`n- parsed every PowerShell script and module with the PowerShell AST parser`n- PSScriptAnalyzer error-level scan on every changed PowerShell file`n- Pester: 5 passed`n`nNo hosted validation was invoked.